### PR TITLE
typedef `SDL_PixelFormatEnum` if SDL version is < 2.0.10

### DIFF
--- a/src/frontend/render.c
+++ b/src/frontend/render.c
@@ -10,6 +10,11 @@
 #include <glad/gl.h>
 #include <volk.h>
 
+// prior to 2.0.10, this was anonymous enum
+#if SDL_COMPILEDVERSION <  SDL_VERSIONNUM(2, 0, 10)
+    typedef int SDL_PixelFormatEnum;
+#endif
+
 int SCREEN_SCALE = 2;
 static SDL_GLContext gl_context;
 SDL_Window* window = NULL;


### PR DESCRIPTION
this was added in this commit <https://github.com/libsdl-org/SDL/commit/1a4c0d4e17e6299d2b84640ba0dcf4738ad4d268#diff-ae4f5426f4d68ca060f0091874b131ca8cb96398e6af6f0d3da74d8bfb53d063>