### PR TITLE
[Draft] Control stick fixes

### DIFF
--- a/src/frontend/device.c
+++ b/src/frontend/device.c
@@ -127,31 +127,31 @@ double copysign(double to, double from) {
 }
 
 void clamp_gamepad(n64_controller_t* controller) {
-    double nameForCardinalAxisValue   = 85.0;
-    double nameForDiagonalValue       = 69.0;
-    double nameForInnerAxialDeadzone  =  7.0;
-    double nameForOuterDeadzoneRadius = 2.0 / sqrt(2.0) * (nameForDiagonalValue / nameForCardinalAxisValue * (nameForCardinalAxisValue - nameForInnerAxialDeadzone) + nameForInnerAxialDeadzone);
-    double ax = trim_gamepad_axis(controller->raw_x) * nameForOuterDeadzoneRadius;
-    double ay = -trim_gamepad_axis(controller->raw_y) * nameForOuterDeadzoneRadius;
+    double max_cardinal   = 85.0;
+    double max_diagonal   = 69.0;
+    double inner_deadzone =  7.0;
+    double outer_deadzone_radius = 2.0 / sqrt(2.0) * (max_diagonal / max_cardinal * (max_cardinal - inner_deadzone) + inner_deadzone);
+    double ax =  trim_gamepad_axis(controller->raw_x) * outer_deadzone_radius;
+    double ay = -trim_gamepad_axis(controller->raw_y) * outer_deadzone_radius;
 
     double len = sqrt(ax*ax+ay*ay);
-    if(len <= nameForOuterDeadzoneRadius) {
-        double lenAbsoluteX = d_abs(ax);
-        double lenAbsoluteY = d_abs(ay);
-        if(lenAbsoluteX <= nameForInnerAxialDeadzone) {
-            lenAbsoluteX = 0.0;
+    if(len <= outer_deadzone_radius) {
+        double len_absolute_x = d_abs(ax);
+        double len_absolute_y = d_abs(ay);
+        if(len_absolute_x <= inner_deadzone) {
+            len_absolute_x = 0.0;
         } else {
-            lenAbsoluteX = (lenAbsoluteX - nameForInnerAxialDeadzone) * nameForCardinalAxisValue / (nameForCardinalAxisValue - nameForInnerAxialDeadzone) / lenAbsoluteX;
+            len_absolute_x = (len_absolute_x - inner_deadzone) * max_cardinal / (max_cardinal - inner_deadzone) / len_absolute_x;
         }
-        ax *= lenAbsoluteX;
-        if(lenAbsoluteY <= nameForInnerAxialDeadzone) {
-            lenAbsoluteY = 0.0;
+        ax *= len_absolute_x;
+        if(len_absolute_y <= inner_deadzone) {
+            len_absolute_y = 0.0;
         } else {
-            lenAbsoluteY = (lenAbsoluteY - nameForInnerAxialDeadzone) * nameForCardinalAxisValue / (nameForCardinalAxisValue - nameForInnerAxialDeadzone) / lenAbsoluteY;
+            len_absolute_y = (len_absolute_y - inner_deadzone) * max_cardinal / (max_cardinal - inner_deadzone) / len_absolute_y;
         }
-        ay *= lenAbsoluteY;
+        ay *= len_absolute_y;
     } else {
-        len = nameForOuterDeadzoneRadius / len;
+        len = outer_deadzone_radius / len;
         ax *= len;
         ay *= len;
     }
@@ -163,14 +163,14 @@ void clamp_gamepad(n64_controller_t* controller) {
         double edgey = copysign(d_min(d_abs(edgex * slope), 85.0f / (1.0f / d_abs(slope) + 16.0f / 69.0f)), ay);
         edgex = edgey / slope;
 
-        double scale = sqrt(edgex*edgex+edgey*edgey) / nameForOuterDeadzoneRadius;
+        double scale = sqrt(edgex*edgex+edgey*edgey) / outer_deadzone_radius;
         ax *= scale;
         ay *= scale;
     }
     
     //clamp excess between nameForCardinalAxisValue and nameForOuterDeadzoneRadius
-    if(d_abs(ax) > nameForCardinalAxisValue) ax = copysign(nameForCardinalAxisValue, ax);
-    if(d_abs(ay) > nameForCardinalAxisValue) ay = copysign(nameForCardinalAxisValue, ay);
+    if(d_abs(ax) > max_cardinal) ax = copysign(max_cardinal, ax);
+    if(d_abs(ay) > max_cardinal) ay = copysign(max_cardinal, ay);
 
     //add epsilon to counteract floating point precision error
     ax = copysign(d_abs(ax) + 1e-03, ax);

--- a/src/frontend/device.c
+++ b/src/frontend/device.c
@@ -89,7 +89,7 @@ void update_button(int controller, n64_button_t button, bool held) {
 
 s8 trim_gamepad_axis(s16 raw) {
     // INT16_MIN through INT16_MAX to -1 through +1
-    return (s16)raw / 32767.0;
+    return (s16)raw / 32767.0; //types or math needs to be reworked here as 32767 is not usable
 }
 
 double d_sign(double x) {
@@ -136,8 +136,8 @@ void clamp_gamepad(n64_controller_t* controller) {
 
     double len = sqrt(ax*ax+ay*ay);
     if(len <= nameForOuterDeadzoneRadius) {
-        auto lenAbsoluteX = d_abs(ax);
-        auto lenAbsoluteY = d_abs(ay);
+        double lenAbsoluteX = d_abs(ax);
+        double lenAbsoluteY = d_abs(ay);
         if(lenAbsoluteX <= nameForInnerAxialDeadzone) {
             lenAbsoluteX = 0.0;
         } else {


### PR DESCRIPTION
This PR is intended to address multiple issues:

1) The range set to 84 was too low for the diagonal values. This is now calculated based upon the maximum cardinal and diagonal values in conjunction with the deadzone size.

2) The deadzone is of the wrong shape and size. This has been corrected to an axial deadzone with a value of 7 that was determined from like-new controllers using image software, a controller test ROM, and deflection angles.

3) Values of type double incur precision error. An epsilon is now used to counteract that precision error before that value becomes truncated when cast to an 8-bit signed integer.

Finally, this PR is set as a draft because it only works fully currently with the keyboard. Additionally, naming and code placement should be discussed.