### PR TITLE
Change control stick approach

### DIFF
--- a/src/frontend/device.h
+++ b/src/frontend/device.h
@@ -111,9 +111,11 @@ void override_joybus_devices_ptr(n64_joybus_device_t* override);
 
 // Exposed for testing
 
-// Trim and apply deadzone
-s8 trim_gamepad_axis(s16 raw);
-// do all requisite clamping for a controller
+// Trim input
+double trim_gamepad_axis(s16 raw);
+// Apply deadzone and scale according to response curve
+double deadzone_corrected_response(double peak_cardinal, double peak_diagonal, double axial_deadzone, double outer_radius, double length, double current_axis_input);
+// Do all requisite clamping for a controller
 void clamp_gamepad(n64_controller_t* controller);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR is intended to change the approach of how control stick input is handled. The previous approach prioritized shape over uniform scaling. Thus, all vertices of the octagon coincided with the circular gate of modern analog stick. Moreover, maximum input in any direction was scaled to fit to the octagon, which resulted in any non-cardinal input to be scaled twice.

This new approach does the following:

1) Sizes a circle (whose radius is effectively the range) that encompasses the entire octagon to avoid the need for scaling to fit the octagonal shape. The radius of the circle is dependent upon the maximum cardinal and diagonal values that an N64 control stick can achieve and the deadzone size.

2) Uses an axial deadzone as opposed to a circular one. This is a better representation of the control stick's mechanical play as the mechanical pieces are tied to either the X or Y direction. Size of the deadzone is set to a value of 7 in accordance to data collected and analyzed from like-new controllers using image software, a controller test ROM, and deflection angles. With this change, scaling is now done on a per-axis basis. Both deadzone and scaling are handled through a new function called  deadzone_corrected_response.

3) Once the edge of the octagon is reached, the input is clamped to the intersecting coordinate.

Lastly, the functions d_sign, d_min, d_abs, and copysign are removed in favor of their built-in C counterparts, and device.h is updated to reflect the change in return type of trim_gamepad_axis to double from s8. The final input passed to the system is still of type s8.